### PR TITLE
Remove `pipefail` from all shell tasks and remove "Disable iommu" task

### DIFF
--- a/roles/1_prepare/tasks/variables-common.yml
+++ b/roles/1_prepare/tasks/variables-common.yml
@@ -88,7 +88,6 @@
 
 - name: Get node drive sizes
   shell: |
-    set -o pipefail
     lsblk -ndo TYPE,NAME,SIZE \
     | grep ^disk \
     | awk '{print $2,$3}'

--- a/roles/3_install-storpool/tasks/post-install.yml
+++ b/roles/3_install-storpool/tasks/post-install.yml
@@ -13,17 +13,6 @@
   tags:
     - skip_ansible_lint
 
-- name: Disable iommu
-  lineinfile:
-    state: present
-    dest: /etc/default/grub
-    backrefs: yes
-    regexp: '^(GRUB_CMDLINE_LINUX=(?!.\$GRUB_CMD)(?!.*iommu)\"[^\"]*)(\".*)'
-    line: '\1 amd_iommu=off\2'
-  when:
-    - sp_vm is defined and
-      not sp_vm | bool
-
 - name: Include distro-specific tasks
   include_tasks: "subtasks/post_install_{{ ansible_os_family|lower }}.yml"
 

--- a/roles/3_install-storpool/tasks/subtasks/support_tools.yml
+++ b/roles/3_install-storpool/tasks/subtasks/support_tools.yml
@@ -20,9 +20,8 @@
 
 - name: Perform mlc test (StorPool Support Tools)
   shell: >
-    set -o pipefail && \
-      [[ ! -d "/tmp/mlc/" ]] && mkdir -p /tmp/mlc/; \
-      [[ ! -f "/tmp/mlc/mlc.output" ]] && {{ sp_toolsdir }}/mlc/mlc > /tmp/mlc/mlc.output || /bin/true
+    [[ ! -d "/tmp/mlc/" ]] && mkdir -p /tmp/mlc/; \
+    [[ ! -f "/tmp/mlc/mlc.output" ]] && {{ sp_toolsdir }}/mlc/mlc > /tmp/mlc/mlc.output || /bin/true
   changed_when: false
   when:
     - sp_vm is defined and

--- a/roles/4_setup-network/tasks/bond_adjustments.yml
+++ b/roles/4_setup-network/tasks/bond_adjustments.yml
@@ -1,7 +1,6 @@
 ---
 - name: Get StorPool interfaces
   shell: |
-    set -o pipefail
     {{ sp_showconf }} -n -e -- SP_IFACE1_CFG SP_IFACE2_CFG \
     | cut -d: -f2 \
     | cut -d. -f1
@@ -16,7 +15,6 @@
 
 - name: Get StorPool bond interface
   shell: |
-    set -o pipefail
     {{ sp_showconf }} -n -e -- SP_IFACE1_CFG \
     | cut -d: -f2 \
     | cut -d. -f1

--- a/roles/4_setup-network/tasks/configure_network.yml
+++ b/roles/4_setup-network/tasks/configure_network.yml
@@ -9,7 +9,6 @@
 
 - name: Init first interface
   shell: |
-    set -o pipefail
     {{ sp_showconf }} -n -e -- SP_IFACE1_CFG \
     | cut -d: -f3 \
     | xargs ifup
@@ -20,7 +19,6 @@
 
 - name: Init second interface
   shell: |
-    set -o pipefail
     {{ sp_showconf }} -n -e -- SP_IFACE2_CFG \
     | cut -d: -f3 \
     | xargs ifup
@@ -32,7 +30,6 @@
 
 - name: Init bond interfaces (if any)
   shell: |
-    set -o pipefail
     {{ sp_showconf }} -n -e -- SP_IFACE1_CFG \
     | cut -d: -f2 \
     | cut -d. -f1 \
@@ -45,7 +42,6 @@
 
 - name: Init iface1 VLANs (if any)
   shell: |
-    set -o pipefail
     {{ sp_showconf }} -n -e -- SP_IFACE1_CFG \
     | cut -d: -f2 \
     | xargs ifup
@@ -56,7 +52,6 @@
 
 - name: Init iface2 VLANs (if any)
   shell: |
-    set -o pipefail
     {{ sp_showconf }} -n -e -- SP_IFACE2_CFG \
     | cut -d: -f2 \
     | xargs ifup

--- a/roles/4_setup-network/tasks/network_validation.yml
+++ b/roles/4_setup-network/tasks/network_validation.yml
@@ -6,7 +6,6 @@
 
 - name: Get StorPool interfaces from storpool.conf
   shell: |
-    set -o pipefail
     {{ sp_showconf }} -n -e -- SP_IFACE1_CFG SP_IFACE2_CFG \
     | cut -d : -f 2,3 \
     | sed -e ':a;N;$!ba;s/\\n/:/g'
@@ -23,7 +22,6 @@
 
 - name: Get StorPool IP addresses from storpool.conf
   shell: |
-    set -o pipefail
     {{ sp_showconf }} -n -e -- SP_IFACE1_CFG SP_IFACE2_CFG \
     | cut -d : -f 2,5
   changed_when: false

--- a/roles/4_setup-network/tasks/subtasks/bond_adjustments_debian.yml
+++ b/roles/4_setup-network/tasks/subtasks/bond_adjustments_debian.yml
@@ -19,7 +19,6 @@
 
 - name: Get {{ sp_bond.stdout }} slave interfaces (Ubuntu/Debian)
   shell: |
-    set -o pipefail
     {{ sp_showconf }} -n -e -- SP_IFACE1_CFG SP_IFACE2_CFG \
     | cut -d: -f3
   changed_when: false

--- a/roles/5_setup-drives/tasks/init-drives.yml
+++ b/roles/5_setup-drives/tasks/init-drives.yml
@@ -57,7 +57,6 @@
 
 - name: Assign drives to servers
   shell: |
-    set -o pipefail
     {{ sp_multi_server_helper }} -i {{ sp_server_instances }} \
     | bash
   changed_when: false


### PR DESCRIPTION
### Remove `pipefail` from all shell tasks
* We are now skipping this for ansible-lint on all shell task and we no longer need to use `pipefail` in order to resolve the `306: Shells that use pipes should set the pipefail option` rule

### Remove "Disable iommu" task
* This step is now handled by an external script and no longer needed in ansible