### PR TITLE
Add flag to skip disk testing for test environments

### DIFF
--- a/roles/initialize_disks/README.md
+++ b/roles/initialize_disks/README.md
@@ -27,6 +27,7 @@ Role Variables
 | sp_hdd_disk_init_args           | List    | []            | List of strings in the form of "--arg1,--arg2" that will be used to initialize HDD devices |
 | sp_discover_disk_run            | Boolean | True          | Designates if the `disk_init_helper` tool should run its discover phase to collect a list with usable devices |
 | disk_init_helper_discovery_file | String  | "/var/spool/storpool/disk-init-discovery.json" | Specifies a path to a JSON file containing the list of devices of to be initialized |
+| sp_test_discovered_disks        | Boolean | True          | Only for SP testing lab use! Whether to test the disks found in the discovery phase of `disk_init_helper` |
 
 
 Dependencies

--- a/roles/initialize_disks/defaults/main.yml
+++ b/roles/initialize_disks/defaults/main.yml
@@ -15,6 +15,7 @@ sp_hdd_disk_init_args: []
 sp_server_instances: 1
 sp_multi_server_helper: '/usr/lib/storpool/multi-server-helper.py'
 sp_new_cluster: false
+sp_test_discovered_disks: true
 
 # This hack-fix sets the same default value that 1_prepare uses. It will be removed once the playbook is reworked
 sp_toolsdir: "/root/storpool"

--- a/roles/initialize_disks/tasks/main.yml
+++ b/roles/initialize_disks/tasks/main.yml
@@ -60,6 +60,7 @@
   set_fact:
     disks_to_be_tested: '{{ disk_discover_json_b64encoded["content"] | b64decode | from_json | dict2items | map(attribute="value") | map(attribute="disk") | list }}'
   when:
+    - sp_test_discovered_disks
     - sp_discover_disk_run
 
 - name: Testing discovered disks
@@ -69,6 +70,7 @@
       - '{{ sp_toolsdir }}/perform_disktest.sh'
       - '{{ disks_to_be_tested | join(" ") }}'
   when:
+    - sp_test_discovered_disks
     - sp_discover_disk_run
     - disks_to_be_tested | length >= 1
 


### PR DESCRIPTION
Testing the disks on every deployment in our test environments, especially the virtual ones, is very time-consuming and rather pointless.