### PR TITLE
Add saving of disk_init_helper data with timestamps

### DIFF
--- a/roles/initialize_disks/README.md
+++ b/roles/initialize_disks/README.md
@@ -28,6 +28,7 @@ Role Variables
 | sp_discover_disk_run            | Boolean | True          | Designates if the `disk_init_helper` tool should run its discover phase to collect a list with usable devices |
 | disk_init_helper_discovery_file | String  | "/var/spool/storpool/disk-init-discovery.json" | Specifies a path to a JSON file containing the list of devices of to be initialized |
 | sp_test_discovered_disks        | Boolean | True          | Only for SP testing lab use! Whether to test the disks found in the discovery phase of `disk_init_helper` |
+| sp_backup_disk_init_config      | Boolean | False         | Save timestamped backups of the `disk_init_helper` discovery command, JSON file, and initialization command |
 
 
 Dependencies

--- a/roles/initialize_disks/defaults/main.yml
+++ b/roles/initialize_disks/defaults/main.yml
@@ -16,6 +16,7 @@ sp_server_instances: 1
 sp_multi_server_helper: '/usr/lib/storpool/multi-server-helper.py'
 sp_new_cluster: false
 sp_test_discovered_disks: true
+sp_backup_disk_init_config: false
 
 # This hack-fix sets the same default value that 1_prepare uses. It will be removed once the playbook is reworked
 sp_toolsdir: "/root/storpool"

--- a/roles/initialize_disks/tasks/main.yml
+++ b/roles/initialize_disks/tasks/main.yml
@@ -48,7 +48,7 @@
     discover_disk_ts: '{{ ansible_date_time.epoch }}'
   when:
     - sp_discover_disk_run
-    - sp_testing_lab
+    - sp_backup_disk_init_config
 
 - name: Save disk discovery command with timestamp
   copy:
@@ -56,7 +56,7 @@
     dest: '{{ disk_init_helper_discovery_file | dirname }}/.discover-cmd_{{ discover_disk_ts }}'
   when:
     - sp_discover_disk_run
-    - sp_testing_lab
+    - sp_backup_disk_init_config
 
 - name: Save disk discovery JSON dump with timestamp
   copy:
@@ -65,7 +65,7 @@
     dest: '{{ disk_init_helper_discovery_file | dirname }}/.discover-json_{{ discover_disk_ts }}'
   when:
     - sp_discover_disk_run
-    - sp_testing_lab
+    - sp_backup_disk_init_config
 
 - name: Copying disk testing tools
   copy:
@@ -127,7 +127,7 @@
     dest: '{{ disk_init_helper_discovery_file | dirname }}/.init-cmd_{{ discover_disk_ts }}'
   when:
     - sp_discover_disk_run
-    - sp_testing_lab
+    - sp_backup_disk_init_config
 
 - name: Assigning disks to servers
   become: true

--- a/roles/initialize_disks/tasks/main.yml
+++ b/roles/initialize_disks/tasks/main.yml
@@ -52,7 +52,7 @@
 
 - name: Save disk discovery command with timestamp
   copy:
-    content: '{{ disk_discovery.cmd | join(" ") }}'
+    content: '{{ disk_discovery.cmd }}'
     dest: '{{ disk_init_helper_discovery_file | dirname }}/.discover-cmd_{{ discover_disk_ts }}'
   when:
     - sp_discover_disk_run
@@ -123,7 +123,7 @@
 
 - name: Save disk initialization command with timestamp
   copy:
-    content: '{{ disk_init.cmd | join(" ") }}'
+    content: '{{ disk_init.cmd }}'
     dest: '{{ disk_init_helper_discovery_file | dirname }}/.init-cmd_{{ discover_disk_ts }}'
   when:
     - sp_discover_disk_run

--- a/roles/initialize_disks/tasks/main.yml
+++ b/roles/initialize_disks/tasks/main.yml
@@ -41,6 +41,31 @@
     {{ sp_discover_disk_pattern if sp_discover_disk_pattern is defined else '' }}
   when:
     - sp_discover_disk_run
+  register: disk_discovery
+
+- name: Generate timestamp for saving disk_init_helper runs
+  set_fact:
+    discover_disk_ts: '{{ ansible_date_time.epoch }}'
+  when:
+    - sp_discover_disk_run
+    - sp_testing_lab
+
+- name: Save disk discovery command with timestamp
+  copy:
+    content: '{{ disk_discovery.cmd | join(" ") }}'
+    dest: '{{ disk_init_helper_discovery_file | dirname }}/.discover-cmd_{{ discover_disk_ts }}'
+  when:
+    - sp_discover_disk_run
+    - sp_testing_lab
+
+- name: Save disk discovery JSON dump with timestamp
+  copy:
+    src: '{{ disk_init_helper_discovery_file }}'
+    remote_src: yes
+    dest: '{{ disk_init_helper_discovery_file | dirname }}/.discover-json_{{ discover_disk_ts }}'
+  when:
+    - sp_discover_disk_run
+    - sp_testing_lab
 
 - name: Copying disk testing tools
   copy:
@@ -94,6 +119,15 @@
     --ssd-args "--no-notify {{ sp_ssd_disk_init_args | join(" ") }}"
     --hdd-args "--no-notify {{ sp_hdd_disk_init_args | join(" ") }}"
     {{ disk_init_helper_discovery_file }}
+  register: disk_init
+
+- name: Save disk initialization command with timestamp
+  copy:
+    content: '{{ disk_init.cmd | join(" ") }}'
+    dest: '{{ disk_init_helper_discovery_file | dirname }}/.init-cmd_{{ discover_disk_ts }}'
+  when:
+    - sp_discover_disk_run
+    - sp_testing_lab
 
 - name: Assigning disks to servers
   become: true


### PR DESCRIPTION
Sometimes useful for investigations in the internal testing lab.