### PR TITLE
Run forced kexec on Ubuntu

### DIFF
--- a/roles/2_setup-infra/files/sp_prepare_kexec
+++ b/roles/2_setup-infra/files/sp_prepare_kexec
@@ -3,10 +3,12 @@
 if [[ -z $* ]]; then
     cat <<EOUSAGE
     Usage: $(basename -- "$0") <kernel_version or 0>
+    set FORCE_KEXEC=1 in the environment to always run 'kexec -fe'
 EOUSAGE
     exit 1
 fi
 kernel_version="$1"
+[[ -z $FORCE_KEXEC ]] && FORCE_KEXEC=0
 now="$(date +"%Y-%m-%d_%H-%M-%S")"
 
 DISTRO_REGEX="CentOS|Red Hat Enterprise Linux Server|AlmaLinux|Debian|Ubuntu"
@@ -141,11 +143,17 @@ prepare_kexec_reboot() {
         reboot
     fi
 
-    logger --stderr -t sp_prepare_kexec "Rebooting into loaded kernel using kexec"
-    if [[ -f "/usr/bin/systemctl" ]]; then
-        /usr/bin/systemctl kexec
+    if [[ $FORCE_KEXEC -eq 1 ]]; then
+        logger --stderr -t sp_prepare_kexec "Rebooting into loaded kernel with forced kexec"
+        kexec -fe
     else
-        kexec -e
+        if [[ -f "/usr/bin/systemctl" ]]; then
+            logger --stderr -t sp_prepare_kexec "Rebooting into loaded kernel using systemctl kexec"
+            /usr/bin/systemctl kexec
+        else
+            logger --stderr -t sp_prepare_kexec "Rebooting into loaded kernel using regular kexec"
+            kexec -e
+        fi
     fi
 
     logger --stderr -t sp_prepare_kexec "Rebooting with kexec has failed, rebooting normally"

--- a/roles/2_setup-infra/tasks/subtasks/boot-specified-kernel.yml
+++ b/roles/2_setup-infra/tasks/subtasks/boot-specified-kernel.yml
@@ -17,9 +17,11 @@
     - ansible_distribution != "Ubuntu"
 
 - name: Prepare new kernel and run forced kexec
-  command: "FORCE_KEXEC=1 /tmp/sp_prepare_kexec {{ sp_kernel_version }}"
+  command: "/tmp/sp_prepare_kexec {{ sp_kernel_version }}"
   async: 1
   poll: 0
+  environment:
+    FORCE_KEXEC: 1
   when:
     - sp_kernel_version is defined
     - not ansible_kernel | regex_search("^" + sp_kernel_version)

--- a/roles/2_setup-infra/tasks/subtasks/boot-specified-kernel.yml
+++ b/roles/2_setup-infra/tasks/subtasks/boot-specified-kernel.yml
@@ -14,6 +14,16 @@
   when:
     - sp_kernel_version is defined
     - not ansible_kernel | regex_search("^" + sp_kernel_version)
+    - ansible_distribution != "Ubuntu"
+
+- name: Prepare new kernel and run forced kexec
+  command: "FORCE_KEXEC=1 /tmp/sp_prepare_kexec {{ sp_kernel_version }}"
+  async: 1
+  poll: 0
+  when:
+    - sp_kernel_version is defined
+    - not ansible_kernel | regex_search("^" + sp_kernel_version)
+    - ansible_distribution == "Ubuntu"
 
 - name: Waiting for host to get back from kexec/reboot
   wait_for_connection:


### PR DESCRIPTION
This is due to `systemctl kexec` hanging the system on Ubuntu LTS releases.