### PR TITLE
Change the default NVMe size to 80GB

### DIFF
--- a/hosts.example
+++ b/hosts.example
@@ -133,7 +133,7 @@ storpool_servers
 # sp_max_disk_size='14TB'
 
 # Minimal size of NVMe drives below which drives won't be discovered to be used by StorPool
-# sp_min_nvme_size='960GB'
+# sp_min_nvme_size='80GB'
 
 # Minimal size of PMEM drives (SSD and HDD) below which drives won't be discovered to be used by StorPool
 # sp_min_pmem_size='1GB'

--- a/roles/initialize_disks/defaults/main.yml
+++ b/roles/initialize_disks/defaults/main.yml
@@ -4,7 +4,7 @@ disk_init_helper_script: '/usr/sbin/disk_init_helper'
 disk_init_helper_discovery_file: '/var/spool/storpool/disk-init-discovery.json'
 sp_discover_disk_run: true
 sp_min_disk_size: '960GB'
-sp_min_nvme_size: '100GB'
+sp_min_nvme_size: '80GB'
 sp_min_pmem_size: '1GB'
 sp_max_disk_size: '14TB'
 sp_nvme_disk_id_offset: 0


### PR DESCRIPTION
There are smaller NVMes than 100GB that can be used for journals. Lower the minimum size so that `disk_init_helper` picks them up.