### PR TITLE
Hackfix the requirement for setting the CGCONFIG_FORCE_STARTUP variable

### DIFF
--- a/roles/configure-cgroups/handlers/main.yml
+++ b/roles/configure-cgroups/handlers/main.yml
@@ -9,8 +9,6 @@
 
 - name: Starting cgconfig
   become: true
-  service:
-    name: cgconfig
-    state: restarted
+  command: "CGCONFIG_FORCE_STARTUP=1 systemctl restart cgconfig"
   listen: "start cgconfig"
   when: sp_cg_start_cgconfig


### PR DESCRIPTION
This is temporary hack to workaround the trouble with the restarting of cgconfig service