### PR TITLE
Make disk_init_helper initialize its disks by default

### DIFF
--- a/roles/initialize_disks/tasks/main.yml
+++ b/roles/initialize_disks/tasks/main.yml
@@ -118,6 +118,7 @@
     {% endif %}
     --ssd-args "--no-notify {{ sp_ssd_disk_init_args | join(" ") }}"
     --hdd-args "--no-notify {{ sp_hdd_disk_init_args | join(" ") }}"
+    --exec
     {{ disk_init_helper_discovery_file }}
   register: disk_init
 


### PR DESCRIPTION
The new version of `disk_init_helper` won't try to create partitions and call `storpool_initdisk` if not called with `--exec`. This PR calls `disk_init_helper` with `--exec` by default.