### PR TITLE
Disable unattended upgrades on Ubuntu

### DIFF
--- a/roles/2_setup-infra/tasks/disable-unattended-upgrades.yml
+++ b/roles/2_setup-infra/tasks/disable-unattended-upgrades.yml
@@ -1,0 +1,17 @@
+- name: Removing lines that enable periodic upgrades
+  lineinfile:
+    path: /etc/apt/apt.conf.d/20auto-upgrades
+    line: "{{ item }}"
+    state: absent
+  loop:
+    - APT::Periodic::Update-Package-Lists "1";
+    - APT::Periodic::Unattended-Upgrade "1";
+
+- name: Adding lines that disable periodic upgrades
+  lineinfile:
+    path: /etc/apt/apt.conf.d/20auto-upgrades
+    line: "{{ item }}"
+    state: absent
+  loop:
+    - APT::Periodic::Update-Package-Lists "0";
+    - APT::Periodic::Unattended-Upgrade "0";

--- a/roles/2_setup-infra/tasks/disable-unattended-upgrades.yml
+++ b/roles/2_setup-infra/tasks/disable-unattended-upgrades.yml
@@ -11,7 +11,7 @@
   lineinfile:
     path: /etc/apt/apt.conf.d/20auto-upgrades
     line: "{{ item }}"
-    state: absent
+    state: present
   loop:
     - APT::Periodic::Update-Package-Lists "0";
     - APT::Periodic::Unattended-Upgrade "0";

--- a/roles/2_setup-infra/tasks/main.yml
+++ b/roles/2_setup-infra/tasks/main.yml
@@ -8,5 +8,10 @@
 - name: Include distro-specific tasks (Setup Infrastructure)
   include_tasks: "subtasks/tune-system-{{ ansible_os_family | lower }}.yml"
 
+- name: Disabling automatic upgrades for Ubuntu
+  include_tasks: disable-unattended-upgrades.yml
+  when:
+    - ansible_distribution == "Ubuntu"
+
 - name: Flush handlers
   meta: flush_handlers


### PR DESCRIPTION
Disable automatic upgrades on Ubuntu. 

Upgrading the Linux kernel before having built StorPool modules might cause a host to fail to join its cluster after a reboot.