### PR TITLE
Use NetworkManager for Enterprise Linux 8 distributions

### DIFF
--- a/roles/0_common/defaults/main.yml
+++ b/roles/0_common/defaults/main.yml
@@ -100,7 +100,6 @@ epel_repo_gpg_key_url: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distributio
 epel_repofile_path: "/etc/yum.repos.d/epel.repo"
 cache_timeout: 600
 
-sp_disable_nm: true
 sp_disable_fw: true
 sp_release_file: "web"
 sp_target_release: "release"

--- a/roles/1_prepare/tasks/check-variables.yml
+++ b/roles/1_prepare/tasks/check-variables.yml
@@ -118,7 +118,6 @@
     - sp_alternative_net_setup
     - sp_overwrite_iface_conf
     - sp_single_iface
-    - sp_disable_nm
     - sp_disable_fw
     - sp_vm
     - sp_summary_wait

--- a/roles/1_prepare/tasks/summary.yml
+++ b/roles/1_prepare/tasks/summary.yml
@@ -4,17 +4,16 @@
     msg: |
       1. OS update: {{ sp_update_system }}
       2. Configure network: {{ sp_configure_network }} ({{ 'overwrite' if sp_overwrite_iface_conf and sp_configure_network else 'do not overwrite' }} existing configuration)
-      3. Network Manager: {{ 'disable' if sp_disable_nm else 'leave as is' }}
-      4. Firewall: {{ 'disable' if sp_disable_fw else 'adjust' }}
-      5. SELinux: {{ sp_selinux }}
-      6. VM Node: {{ sp_vm }} ({{ 'Guessed' if sp_vm_guessed is defined else 'Defined' }}) (Product Name: {{ ansible_product_name }})
-      7. New Cluster: {{ sp_new_cluster }}
-      8. StorPool release: {{ sp_release }}
-      9. Release Source: {{ sp_release_file }}
-      10. Path to storpool.conf: {{ sp_config }}
-      11. StorPool node roles: {{ sp_node_roles }}
-      12. StorPool services that will be installed: {{ sp_install_services }}
-      15. StorPool control groups configuration + extra configuration: {{ sp_cg_conf_extra | default('default') }}
+      3. Firewall: {{ 'disable' if sp_disable_fw else 'adjust' }}
+      4. SELinux: {{ sp_selinux }}
+      5. VM Node: {{ sp_vm }} ({{ 'Guessed' if sp_vm_guessed is defined else 'Defined' }}) (Product Name: {{ ansible_product_name }})
+      6. New Cluster: {{ sp_new_cluster }}
+      7. StorPool release: {{ sp_release }}
+      8. Release Source: {{ sp_release_file }}
+      9. Path to storpool.conf: {{ sp_config }}
+      10. StorPool node roles: {{ sp_node_roles }}
+      11. StorPool services that will be installed: {{ sp_install_services }}
+      12. StorPool control groups configuration + extra configuration: {{ sp_cg_conf_extra | default('default') }}
 
 - name: Confirm configuration
   pause:

--- a/roles/2_setup-infra/tasks/subtasks/dependencies-redhat.yml
+++ b/roles/2_setup-infra/tasks/subtasks/dependencies-redhat.yml
@@ -28,10 +28,3 @@
 
 - name: Include tasks for setting default kernel
   include_tasks: "boot-specified-kernel.yml"
-
-- name: Install network-scripts (CentOS 8/RHEL 8)
-  yum:
-    name: network-scripts
-    state: present
-  when:
-    - ansible_distribution_major_version == '8'

--- a/roles/2_setup-infra/tasks/subtasks/tune-system-redhat.yml
+++ b/roles/2_setup-infra/tasks/subtasks/tune-system-redhat.yml
@@ -68,20 +68,6 @@
   when:
     - ansible_distribution_major_version != '6'
 
-- name: Disable NetworkManager (CentOS/RHEL)
-  service:
-    name: "NetworkManager.service"
-    enabled: false
-    state: stopped
-  register: nm_service_status
-  failed_when:
-    - nm_service_status is failed
-    - not ('Could not find the requested service' in nm_service_status.msg)
-  when:
-    - ansible_distribution_major_version not in ['6', '8']
-    - sp_disable_nm is defined
-    - sp_disable_nm | bool
-
 - name: Configure SELinux (CentOS/RHEL)
   selinux:
     state: "{{ sp_selinux | default('disabled') }}"

--- a/roles/4_setup-network/tasks/configure_network.yml
+++ b/roles/4_setup-network/tasks/configure_network.yml
@@ -8,7 +8,18 @@
   when: sp_alternative_net_setup
 
 - name: Generate StorPool net interfaces configuration
-  command: "/usr/sbin/iface-genconf -a {{ '-o' if sp_overwrite_iface_conf else '' }} {{ '--nettype 0' if sp_single_iface else '' }}"
+  command:
+    cmd: >-
+      /usr/sbin/iface-genconf -a
+      {% if sp_overwrite_iface_conf %}
+      -o
+      {% endif %}
+      {% if sp_single_iface %}
+      --nettype 0
+      {% endif %}
+      {% if disable_nm is defined and disable_nm %}
+      --nm-controlled
+      {% endif %}
   register: iface_genconf
   when: not sp_alternative_net_setup
   changed_when: false

--- a/roles/4_setup-network/tasks/configure_network.yml
+++ b/roles/4_setup-network/tasks/configure_network.yml
@@ -17,7 +17,7 @@
       {% if sp_single_iface %}
       --nettype 0
       {% endif %}
-      {% if disable_nm is defined and disable_nm %}
+      {% if disable_nm is defined and not disable_nm %}
       --nm-controlled
       {% endif %}
   register: iface_genconf

--- a/roles/4_setup-network/tasks/subtasks/configure_network_redhat.yml
+++ b/roles/4_setup-network/tasks/subtasks/configure_network_redhat.yml
@@ -12,7 +12,7 @@
 
 - name: Determining whether to disable NetworkManager
   set_fact:
-    disable_nm: "{{ sp_disable_nm | bool if sp_disable_nm is defined else (redhat_disable_nm_map | dict2items(key_name='version', value_name='value') | selectattr('version', 'eq', ansible_distribution_major_version) | first).value | bool }}"
+    disable_nm: "{{ sp_disable_nm | bool if sp_disable_nm is defined else lookup('vars', 'redhat_' + ansible_distribution_major_version + '_disable_nm') | bool }}"
 
 - name: Configuring the NetworkManager service
   systemd:

--- a/roles/4_setup-network/tasks/subtasks/configure_network_redhat.yml
+++ b/roles/4_setup-network/tasks/subtasks/configure_network_redhat.yml
@@ -12,7 +12,7 @@
 
 - name: Determining whether to disable NetworkManager
   set_fact:
-    disable_nm: "{{ sp_disable_nm | bool if sp_disable_nm is defined else redhat_disable_nm_map[ansible_distribution_major_version] | bool }}"
+    disable_nm: "{{ sp_disable_nm | bool if sp_disable_nm is defined else (redhat_disable_nm_map | dict2items(key_name='version', value_name='value') | selectattr('version', 'eq', ansible_distribution_major_version) | first).value | bool }}"
 
 - name: Configuring the NetworkManager service
   systemd:

--- a/roles/4_setup-network/tasks/subtasks/configure_network_redhat.yml
+++ b/roles/4_setup-network/tasks/subtasks/configure_network_redhat.yml
@@ -4,6 +4,12 @@
     dest: /sbin
     mode: 0755
 
+- name: Dumping value of sp_disable_nm
+  debug:
+    var: sp_disable_nm
+    verbosity: 2
+  when: sp_disable_nm is defined
+
 - name: Determining whether to disable NetworkManager
   set_fact:
     disable_nm: "{{ sp_disable_nm | bool if sp_disable_nm is defined else redhat_disable_nm_map[ansible_distribution_major_version] | bool }}"

--- a/roles/4_setup-network/tasks/subtasks/configure_network_redhat.yml
+++ b/roles/4_setup-network/tasks/subtasks/configure_network_redhat.yml
@@ -12,7 +12,7 @@
   systemd:
     name: NetworkManager
     state: "{{ disable_nm | ternary ('stopped', 'started') }}"
-    enabled: "{{ disable_nm | not }}"
+    enabled: "{{ not disable_nm }}"
 
 - name: Installing network-scripts (CentOS 8/RHEL 8)
   yum:

--- a/roles/4_setup-network/tasks/subtasks/configure_network_redhat.yml
+++ b/roles/4_setup-network/tasks/subtasks/configure_network_redhat.yml
@@ -1,12 +1,28 @@
----
 - name: Deploy ifup-pre-local (CentOS/RHEL)
   copy:
     src: ifup-pre-local
     dest: /sbin
     mode: 0755
 
-- name: Enable network-scripts on CentOS 8
-  service:
+- name: Determining whether to disable NetworkManager
+  set_fact:
+    disable_nm: "{{ sp_disable_nm | bool if sp_disable_nm is defined else redhat_disable_nm_map[ansible_distribution_major_version] | bool }}"
+
+- name: Configuring the NetworkManager service
+  systemd:
+    name: NetworkManager
+    state: "{{ disable_nm | ternary ('stopped', 'started') }}"
+    enabled: "{{ disable_nm | not }}"
+
+- name: Installing network-scripts (CentOS 8/RHEL 8)
+  yum:
+    name: network-scripts
+    state: present
+  when:
+    - disable_nm
+    - ansible_distribution_major_version | int == 8
+
+- name: Enabling network-scripts on CentOS
+  systemd:
     name: network
-    enabled: true
-  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == '8'
+    enabled: "{{ disable_nm }}"

--- a/roles/4_setup-network/vars/main.yml
+++ b/roles/4_setup-network/vars/main.yml
@@ -1,2 +1,2 @@
-redhat_7_disable_nm_map: false
-redhat_8_disable_nm_map: false
+redhat_7_disable_nm: true
+redhat_8_disable_nm: false

--- a/roles/4_setup-network/vars/main.yml
+++ b/roles/4_setup-network/vars/main.yml
@@ -1,0 +1,3 @@
+redhat_disable_nm_map:
+  7: true
+  8: false

--- a/roles/4_setup-network/vars/main.yml
+++ b/roles/4_setup-network/vars/main.yml
@@ -1,3 +1,2 @@
-redhat_disable_nm_map:
-  7: true
-  8: false
+redhat_7_disable_nm_map: false
+redhat_8_disable_nm_map: false


### PR DESCRIPTION
Network-scripts are deprecated in EL8 and will most probably be removed from EL9. 
This PR makes NetworkManager the default tool for networking on EL 8 distributions. The user can still force whether to use it or not.