### PR TITLE
Use our own file for disabling apt unattended upgrades

### DIFF
--- a/roles/2_setup-infra/tasks/disable-unattended-upgrades.yml
+++ b/roles/2_setup-infra/tasks/disable-unattended-upgrades.yml
@@ -1,17 +1,9 @@
-- name: Removing lines that enable periodic upgrades
-  lineinfile:
-    path: /etc/apt/apt.conf.d/20auto-upgrades
-    line: "{{ item }}"
-    state: absent
-  loop:
-    - APT::Periodic::Update-Package-Lists "1";
-    - APT::Periodic::Unattended-Upgrade "1";
-
 - name: Adding lines that disable periodic upgrades
   lineinfile:
-    path: /etc/apt/apt.conf.d/20auto-upgrades
+    path: /etc/apt/apt.conf.d/999storpool
     line: "{{ item }}"
     state: present
+    create: true
   loop:
     - APT::Periodic::Update-Package-Lists "0";
     - APT::Periodic::Unattended-Upgrade "0";


### PR DESCRIPTION
It's better to manage our own file that disables the automatic upgrades on Debian-like OS.