### PR TITLE
Install required collections from Github instead of Galaxy

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,4 +1,6 @@
 ---
 collections:
-  - ansible.posix
-  - community.general
+  - src: https://github.com/ansible-collections/ansible.posix.git
+    name: ansible.posix
+  - src: https://github.com/ansible-collections/community.general
+    name: community.general


### PR DESCRIPTION
Due to frequent errors when pulling from Ansible Galaxy.