### PR TITLE
Fix determining if NetworkManager is installed

### DIFF
--- a/roles/configure_networking/tasks/configure_network.yml
+++ b/roles/configure_networking/tasks/configure_network.yml
@@ -67,7 +67,8 @@
   when:
     - sp_disable_nm
     - ansible_os_family == "RedHat"
-    - '"NetworkManager.service" in ansible_facts.services'
+    - ansible_facts.services["NetworkManager.service"] is defined
+    - ansible_facts.services["NetworkManager.service"]["status"] != "not-found"
 
 - name: Creating temporary configuration file
   ansible.builtin.tempfile:


### PR DESCRIPTION
Ansible gathers systemd services even if a unit is not on the machine. The service will report its status as `not-found`. Check for the status field and its value to better determine if NetworkManager is installed.