### PR TITLE
Fixes to allow removing the initdisks script

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -59,6 +59,8 @@
       include_tasks: tasks/generate_group_membership.yml
       when:
         - sp_create_groups_by_services
+      tags:
+        - initialize-disks
   roles:
     - initialize_disks
   tags:

--- a/playbook.yml
+++ b/playbook.yml
@@ -53,7 +53,9 @@
 
 - name: Configure Drives
   hosts: storpool_server
-  gather_facts: false
+  gather_facts: "{{'initialize-disks' in ansible_run_tags}}"
+  gather_subset:
+    - "min"
   roles:
     - initialize_disks
   tags:

--- a/playbook.yml
+++ b/playbook.yml
@@ -17,6 +17,17 @@
   tags:
     - always
 
+- name: Build in-memory inventory groups
+  hosts: storpool
+  gather_facts: false
+  tasks:
+    - name: Generate group memberships
+      ansible.builtin.import_tasks: tasks/generate_group_membership.yml
+      when:
+        - sp_create_groups_by_services
+  tags:
+    - always
+
 - name: Configuring hosts
   hosts: storpool
   gather_facts: yes
@@ -28,12 +39,6 @@
 
 - name: Installing StorPool components
   hosts: storpool
-  pre_tasks:
-    - name: Building in-memory inventory groups
-      import_tasks: tasks/generate_group_membership.yml
-      when:
-        - sp_create_groups_by_services
-
   roles:
     - install_storpool_components
   tags:
@@ -41,11 +46,6 @@
 
 - name: Configuring Networking
   hosts: storpool
-  pre_tasks:
-    - name: Building in-memory inventory groups
-      include_tasks: tasks/generate_group_membership.yml
-      when:
-        - sp_create_groups_by_services
   roles:
     - configure_networking
   tags:
@@ -54,13 +54,6 @@
 - name: Configure Drives
   hosts: storpool_server
   gather_facts: false
-  pre_tasks:
-    - name: Building in-memory inventory groups
-      include_tasks: tasks/generate_group_membership.yml
-      when:
-        - sp_create_groups_by_services
-      tags:
-        - initialize-disks
   roles:
     - initialize_disks
   tags:

--- a/roles/initialize_disks/tasks/main.yml
+++ b/roles/initialize_disks/tasks/main.yml
@@ -70,7 +70,6 @@
   set_fact:
     discover_disk_ts: '{{ ansible_date_time.epoch }}'
   when:
-    - sp_discover_disk_run
     - sp_backup_disk_init_config
 
 - name: Save disk discovery command with timestamp
@@ -166,7 +165,6 @@
     content: '{{ disk_init.cmd }}'
     dest: '{{ disk_init_helper_discovery_file | dirname }}/.init-cmd_{{ discover_disk_ts }}'
   when:
-    - sp_discover_disk_run
     - sp_backup_disk_init_config
 
 - name: Assigning disks to servers

--- a/roles/initialize_disks/tasks/main.yml
+++ b/roles/initialize_disks/tasks/main.yml
@@ -18,10 +18,10 @@
 - name: Verifying disk ID offset
   assert:
     that:
-      - node_id|int - sp_disk_offset|int > 0
-    fail_msg: 'sp_disk_offest value ({{ sp_disk_offset }}) is too high for host {{ inventory_hostname }} with ID {{ node_id }}'
+      - node_id|int - sp_diskid_offset|int > 0
+    fail_msg: 'sp_diskid_offset value ({{ sp_diskid_offset }}) is too high for host {{ inventory_hostname }} with ID {{ node_id }}'
   when:
-    - sp_disk_offset is defined
+    - sp_diskid_offset is defined
 
 - name: Removing previous disk discovery configuration
   become: true

--- a/roles/initialize_disks/tasks/main.yml
+++ b/roles/initialize_disks/tasks/main.yml
@@ -34,14 +34,20 @@
 - name: Stopping multipathd before disk discovery
   become: yes
   ansible.builtin.systemd:
-    name: "{{ item }}"
+    name: multipathd.service
     state: stopped
-  loop:
-    - multipathd.service
-    - multipathd.socket
   when:
     - sp_discover_disk_run
     - ansible_facts.services["multipathd.service"] is defined
+
+- name: Stopping multipathd socket before disk discovery
+  become: yes
+  ansible.builtin.systemd:
+    name: multipathd.socket
+    state: stopped
+  when:
+    - sp_discover_disk_run
+    - ansible_facts.services["multipathd.socket"] is defined
 
 - name: Discovering suitable disks
   become: true
@@ -139,14 +145,20 @@
 - name: Starting multipathd after disk initialization
   become: yes
   ansible.builtin.systemd:
-    name: "{{ item }}"
+    name: multipathd.service
     state: started
-  loop:
-    - multipathd.socket
   when:
     - sp_discover_disk_run
     - ansible_facts.services["multipathd.service"] is defined
-    - ansible_facts.services["multipathd.service"]["state"] == "running"
+
+- name: Starting multipathd socket after disk initialization
+  become: yes
+  ansible.builtin.systemd:
+    name: multipathd.socket
+    state: started
+  when:
+    - sp_discover_disk_run
+    - ansible_facts.services["multipathd.socket"] is defined
 
 - name: Save disk initialization command with timestamp
   become: yes


### PR DESCRIPTION
So we can unify production and internal test deployments.