### PR TITLE
install_storpool_components: add pre-installation script hook

### DIFF
--- a/roles/install_storpool_components/tasks/post_install.yml
+++ b/roles/install_storpool_components/tasks/post_install.yml
@@ -100,7 +100,7 @@
     - Update GRUB configuration
     - Reboot host
 
-- name: Execuite StorPool components post-installation hook
+- name: Execute StorPool components post-installation hook
   become: yes
   ansible.builtin.shell: "{{ sp_post_install_components_hook }}"
   when:

--- a/roles/install_storpool_components/tasks/pre_install.yml
+++ b/roles/install_storpool_components/tasks/pre_install.yml
@@ -30,7 +30,7 @@
   tags:
     - test-memory
 
-- name: Execuite StorPool components pre-installation hook
+- name: Execute StorPool components pre-installation hook
   become: yes
   ansible.builtin.shell: "{{ sp_pre_install_components_hook }}"
   when:

--- a/roles/install_storpool_components/tasks/pre_install.yml
+++ b/roles/install_storpool_components/tasks/pre_install.yml
@@ -29,3 +29,9 @@
     - not sp_vm | bool
   tags:
     - test-memory
+
+- name: Execuite StorPool components pre-installation hook
+  become: yes
+  ansible.builtin.shell: "{{ sp_pre_install_components_hook }}"
+  when:
+    - sp_pre_install_components_hook is defined


### PR DESCRIPTION
Current use case is chasing down some network connectivity issues, but it would be nice to have in general.