### PR TITLE
storpool-sed-unlock: Change partprobe for hdparm -z

### DIFF
--- a/roles/9_sed/files/storpool-sed-unlock
+++ b/roles/9_sed/files/storpool-sed-unlock
@@ -77,9 +77,9 @@ def main():
                         log.error('storpool-sed-unlock: Unable to enable MBRDone for {}'.format(udev_device))
 
                     try:
-                        partprobe_output = subprocess.check_output(
-                            ['/usr/sbin/partprobe', '/dev/disk/by-id/{}'.format(udev_device)],
-                            shell=False
+                        other_output = subprocess.check_output(
+                             ['/usr/sbin/hdparm', '-z', '/dev/disk/by-id/{}'.format(udev_device)],
+                             shell=False
                         )
 
                         log.info('storpool-sed-unlock: Re-read {}'.format(udev_device))
@@ -102,10 +102,11 @@ def main():
                         log.error('storpool-sed-unlock: Unable to unlock {}'.format(udev_device))
 
                     try:
-                        partprobe_output = subprocess.check_output(
-                            ['/usr/sbin/partprobe', '/dev/disk/by-id/{}'.format(udev_device)],
-                            shell=False
+                        other_output = subprocess.check_output(
+                             ['/usr/sbin/hdparm', '-z', '/dev/disk/by-id/{}'.format(udev_device)],
+                             shell=False
                         )
+
 
                         log.info('storpool-sed-unlock: Re-read {}'.format(udev_device))
 


### PR DESCRIPTION
Using partprobe for scanning of partitions at inside a udev script leads to it being killed, due to an enormous quantity of syscalls it uses (a suspicion). hdparm -z uses just one for the actual probing, and hasn't shown any issues with using it in a udev script so far.